### PR TITLE
more precision for model scale textfield

### DIFF
--- a/objects/ModelScale.gml
+++ b/objects/ModelScale.gml
@@ -6,7 +6,7 @@ applies_to=self
 */
 with (Controller) {
     var new_scale;
-    new_scale=real(get_string("Scale",string(scale)))
+    new_scale=real(get_string("Scale",string_better(scale)))
     if (new_scale!=0) {
         scale=new_scale
         generate_models()
@@ -21,5 +21,5 @@ action_id=603
 applies_to=self
 */
 draw_text(x,y-40,"Model scale")
-draw_text(x,y-20,Controller.scale)
+draw_text(x,y-20,string_better(Controller.scale))
 event_inherited()


### PR DESCRIPTION
This change increases the precision used for the "model scale" field so that small numbers like 0.0025 won't get simplified to 0.00.